### PR TITLE
types-jsonschema 4.26.0.20260518 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "types-jsonschema" %}
-{% set version = "4.25.1.20251009" %}
+{% set version = "4.26.0.20260518" %}
 
 package:
   name: {{ name }}
@@ -7,18 +7,18 @@ package:
 
 source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-    sha256: 75d0f5c5dd18dc23b664437a0c1a625743e8d2e665ceaf3aecb29841f3a5f97f
+    sha256: e1dd53dc97a64f5eccdd6fa9839666e09bb500a8ebba2db6fdaf1789faea81a6
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   host:
     - pip
     - python
-    - setuptools >=77.0.3
+    - setuptools >=82.0.1
   run:
     - python
     - referencing


### PR DESCRIPTION
types-jsonschema 4.26.0.20260518 

**Destination channel:** Defaults

### Links

- [PKG-16832]
- dev_url:        https://github.com/python/typeshed/tree/main
- conda_forge:    https://github.com/conda-forge/types-jsonschema-feedstock
- pypi:           https://pypi.org/project/types-jsonschema/4.26.0.20260518
- pypi inspector: https://inspector.pypi.io/project/types-jsonschema/4.26.0.20260518

### Explanation of changes:

- new version number


[PKG-16832]: https://anaconda.atlassian.net/browse/PKG-16832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ